### PR TITLE
Add more documentation from HACKING

### DIFF
--- a/contributing/contributing-changes.rst
+++ b/contributing/contributing-changes.rst
@@ -3,6 +3,15 @@
 Contributing changes
 ====================
 
+If you have a patch to fix a problem in Xapian, or to add a new feature,
+please send it to us for inclusion.  Any major changes should be discussed
+on `the xapian-devel mailing list <https://xapian.org/lists>`_ first.
+
+The rest of this section gives information on how to get your changes
+adopted quickly into Xapian. We have noted some things we aim for in our
+code and our changes, as well as how to get changes to us and some other
+details.
+
 .. _patch-guidelines:
 
 Some things that we look for

--- a/contributing/contributing-changes.rst
+++ b/contributing/contributing-changes.rst
@@ -180,6 +180,20 @@ you to this file, unless you specifically request us not to. If you see we
 have forgotten to do this, please draw it to our attention so that we can
 address the omission.
 
+Update trac
+-----------
+
+If there's a related trac ticket or other reference for a bug or feature,
+update it (if the issue is completely addressed by the changes you've made,
+then close it). It's also good to mention it in the commit message -- it's a
+great help to future developers trying to work out why a change was made.
+
+If you've fixed a bug, it's helpful to update the release notes for the
+most recent release with a copy of the patch.  If the commit from git
+applies cleanly, you can just link to it.  If it fails to apply, please
+attach an adjusted patch which does. If there are conflicts in test cases
+which aren't easy to resolve, it is fine to just drop those changes from the
+patch if we can still be confident that the issue is actually fixed by the patch.
 
 Consider backporting bug fixes
 ------------------------------

--- a/contributing/contributing-changes.rst
+++ b/contributing/contributing-changes.rst
@@ -12,6 +12,16 @@ adopted quickly into Xapian. We have noted some things we aim for in our
 code and our changes, as well as how to get changes to us and some other
 details.
 
+License grant
+-------------
+
+We ask everyone contributing changes to Xapian to :ref:`dual-license
+<licensing>` under the GPL (which Xapian currently uses) and the MIT/X
+license (which we would like to move to in future). The simplest way
+to do this is to drop an email to the xapian-devel `mailing list
+<https://xapian.org/lists>`_ stating that you own the copyright on your
+changes and are happy to dual-license accordingly.
+
 .. _patch-guidelines:
 
 Some things that we look for
@@ -137,16 +147,6 @@ If there's an active release branch, please check if the bug is present
 in that branch, and if the fix is appropriate to backport - if the fix
 breaks ABI compatibility or is very invasive, you may need to fix it in
 a different way for the release branch, or decide not to backport the fix.
-
-License grant
--------------
-
-We ask everyone contributing changes to Xapian to :ref:`dual-license
-<licensing>` under the GPL (which Xapian currently uses) and the MIT/X
-license (which we would like to move to in future). The simplest way
-to do this is to drop an email to the xapian-devel `mailing list
-<https://xapian.org/lists>`_ stating that you own the copyright on your
-changes and are happy to dual-license accordingly.
 
 Submit your patch
 -----------------

--- a/contributing/contributing-changes.rst
+++ b/contributing/contributing-changes.rst
@@ -230,6 +230,13 @@ We find patches in unified diff format easiest to work with. ``git diff``
 produces the right output for a single commit (or ``git format-patch``
 for a series of commits).
 
+If you're working from a tarball, you can unpack a second clean copy of the
+files and compare the two versions with ``diff -pruN`` (``-p`` reports the function
+name for each chunk, ``-r`` acts recursively, ``-u`` does a unified diff, and ``-N`` shows
+new files in the diff).  Alternatively ``ptardiff`` (which comes with perl, at
+least on Debian and Ubuntu) can diff against the original tarball, unpacking
+it on the fly.
+
 Someone from the community will then be able to review the patch
 and decide if it needs further work before integrating. If so,
 they'll leave comments on the trac ticket (trac will generally

--- a/contributing/contributing-changes.rst
+++ b/contributing/contributing-changes.rst
@@ -124,7 +124,43 @@ If you're adding a new feature, you'll want to write tests that
 it behaves correctly. Thinking about the tests you need to
 write can often help you plan how to implement the feature; it
 can also help when thinking about what API any new classes or
-methods should expose.
+methods should expose. A good set of tests will both ensure
+that the feature isn't broken to start with and detect if later
+changes stop it working as intended.
+
+And of course you should check that the existing tests all continue to
+pass. It's good practice to get into the habit of running tests locally
+as part of your development process, and certainly before you share
+changes with others, such as by opening a Pull Request or sending us a
+patch.
+
+If you don't know how to write tests using the Xapian test rig, then please
+ask.  It's reasonably simple once you've done it once.  There is a brief
+introduction to the Xapian test system in ``docs/tests.html``, as well as
+some helpful information in the :doc:`../tests/index` section of this guide.
+
+
+.. note::
+
+   If you're adding a new testcase to demonstrate an existing bug, and not
+   checking a fix in at the same time, mark the testcase as a known failure (by
+   calling ``XFAIL("explanatory message")`` at the start of your testcase (if
+   necessary this can be conditional on backend or other factors - the backend
+   case has explicit support via ``XFAIL_FOR_BACKEND("backend", "message")``).
+
+   This will mean that this testcase failing will be reported as "XFAIL" which
+   won't cause the test run to fail.  If such a testcase in fact passes, that
+   gets reported as "XPASS" and *will* cause the test run to fail.  A testcase
+   should not be flagged as "XFAIL" for a long time, but it can be useful to be
+   able to add such testcases during development.  It also allows a patch
+   series which fixes a bug to first demonstrate the bug via a new testcase
+   marked as "XFAIL", then fix the bug and remove the "XFAIL" -- this makes it
+   clear that the regression test actually failed before the fix.
+
+   Note that failures which are due to valgrind errors or leaked fds are not
+   affected by this macro -- such errors are inherently not suitable for "XFAIL"
+   as they go away when the testsuite is run without valgrind or on a platform
+   where our fd leak detector code isn't supported.
 
 Updated attributions
 ~~~~~~~~~~~~~~~~~~~~

--- a/contributing/contributing-changes.rst
+++ b/contributing/contributing-changes.rst
@@ -174,7 +174,12 @@ added files which you've written from scratch, they should
 include the GPL boilerplate with your name only.
 
 If you're not in there already, add yourself to the
-``xapian-core/AUTHORS`` file.
+``xapian-core/AUTHORS`` file. If you forget, as well as if we have used
+patches from you, or received helpful reports or advice, we will add
+you to this file, unless you specifically request us not to. If you see we
+have forgotten to do this, please draw it to our attention so that we can
+address the omission.
+
 
 Consider backporting bug fixes
 ------------------------------

--- a/getting-started/index.rst
+++ b/getting-started/index.rst
@@ -131,7 +131,7 @@ If you want to be able to build distribution tarballs (with ``make dist``) then
 you'll also need some further tools:
 
 * doxygen (v1.8.8 is used for 1.3.x snapshots and releases; 1.7.6.1 fails to
-  process trunk after ``PL2Weight`` was added).
+  process git master after ``PL2Weight`` was added).
 * dot (part of Graphviz.  Doxygen's ``DOT_MULTI_TARGETS`` option apparently needs
   ">1.8.10")
 * help2man

--- a/getting-started/index.rst
+++ b/getting-started/index.rst
@@ -145,6 +145,21 @@ directory that was created earlier when you cloned the source code:
 To download tools, bootstrap will use ``wget``, ``curl`` or
 ``lwp-request`` if installed.  If not, it will give an error telling
 you the URL to download from by hand and where to copy the file to.
+If you wish to prevent bootstrap from downloading and building the autotools
+pass the ``--without-autotools`` option.  You can force it to delete the downloaded
+and installed versions by passing ``--clean``.
+
+Our bootstrap script will check which directories you have checked out,
+so you can bootstrap a partial tree.  You can also ``touch .nobootstrap`` in
+a subdirectory to tell bootstrap to ignore it.
+
+If you need to add any extra macro directories to the path searched by aclocal
+(which is part of automake), you can do this by specifying these in the
+``ACLOCAL_FLAGS`` environment variable. For instance:
+
+.. code-block:: bash
+
+   $ ACLOCAL_FLAGS=-I/extra/macro/directory ./bootstrap
 
 .. note::
 
@@ -194,6 +209,19 @@ slightly awkward:
 .. code-block:: bash
 
    $ ./configure --without-perl --without-tcl
+
+Our configure script supports building in a separate directory to
+the sources. Simply create the directory you want to build in, and then run the
+configure script from inside that directory.  For example, to build in a
+directory called "build" (starting in the top level source directory):
+
+.. code-block:: bash
+
+   $ ./bootstrap
+   # output from bootstrap
+   $ mkdir build
+   $ cd build
+   $ ../configure
 
 Building Xapian
 ~~~~~~~~~~~~~~~
@@ -255,7 +283,15 @@ the following may be of use.
 ``--enable-documentation``
 	This tells configure to enable make dependencies for regenerating
 	documentation files.  By default it uses the same setting as
-	``--enable-maintainer-mode``.
+	``--enable-maintainer-mode``. You can turn off documentation
+        rules in maintainer mode (which means that documentation won't be
+        rebuilt on ``make check``, which will save some time) by passing
+        ``--disable-documentation`` to configure.
+
+        Note that ``make dist`` requires the documentation to have been
+        built, and so won't work with a git checkout if you disable
+        building the documentation. You can still configure and build the
+        code itself.
 
 Xapian's build system has a lot of other options you can use to
 control exactly what gets built and in what ways. Check out help

--- a/getting-started/index.rst
+++ b/getting-started/index.rst
@@ -78,8 +78,54 @@ using:
 (We install documentation tools for both python2 and python3, in the
 same way we build the bindings for both of them.)
 
-.. On Fedora, yum install libuuid-devel; we need more to bother
-   including this.
+Windows
+~~~~~~~
+
+Building using MSVC is supported by the autotools build system.  You need
+to install a set of Unix-like tools first -- we recommend `MSYS2
+<https://www.msys2.org/>`_.
+
+For details of how to specify MSVC to ``configure`` see the "INSTALL" document
+in ``xapian-core``.
+
+When building from git, by default you'll need some extra tools to generate
+Unicode tables (Tcl) and build documentation (doxygen, help2man, sphinx-doc).
+We don't currently have detailed advice on how to do this (if you can provide
+some then please send a patch).
+
+You can avoid needing Tcl by copying ``xapian-core/unicode/unicode-data.cc``
+from another platform or a release which uses the same Unicode version.  You
+can avoid needing most of the documentation tools by running configure with
+the ``--disable-documentation`` option.
+
+On other platforms
+~~~~~~~~~~~~~~~~~~
+
+You will need the following tools installed to build from git:
+
+* GNU m4 >= 4.6 (for autoconf)
+* perl >= 5.6 (for automake; also for various maintainer scripts)
+* python >= 2.3 (for generating the Python bindings)
+* GNU make (or another make which support VPATH for explicit rules)
+* GNU bison (for building SWIG, used for generating the bindings)
+* Tcl (to generate unicode/unicode-data.cc)
+
+There are also a number of libraries you'll need available, including
+development headers:
+
+* `zlib1g <https://zlib.net>`_
+* `libuuid <https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/tree/libuuid>`_
+* `PCRE <https://www.pcre.org>`_
+* libmagic (which is part of `the open source implementation of file(1) <https://www.darwinsys.com/file/>`_)
+
+.. On Fedora, yum install libuuid-devel -- can we get a more complete list?
+
+If you're doing much development work, you'll probably also want the following
+tools installed:
+
+* `valgrind <http://valgrind.org/>`_ for better testsuite error finding
+* `ccache <https://ccache.dev>`_ for faster rebuilds
+* `eatmydata <https://www.flamingspork.com/projects/libeatmydata/>`_ for faster testsuite runs
 
 Building Xapian
 ---------------

--- a/getting-started/index.rst
+++ b/getting-started/index.rst
@@ -133,10 +133,18 @@ Building Xapian
 Bootstrapping the code
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Xapian needs to set up a few things with a fresh clone of the code, as
-well as downloading and building some tools for which we require very
-precise versions. You should run this command in the ``xapian``
-directory that was created earlier when you cloned the source code:
+The repository does not contain any automatically generated files
+(such as ``configure``, ``Makefile.in``, Snowball-generated stemmers, Lemon-generated
+parsers, SWIG-generated code, and so on) because experience shows it's best to keep
+these out of version control.  To avoid requiring you to install the correct
+versions of the tools required, we either include the source to these tools in
+the repo directly (in the case of Snowball and Lemon), or the bootstrap script
+will download them as tarballs (autoconf, automake, libtool) or
+from git (SWIG), build them, and install them within the source tree.
+
+The bootstrap script doesn't care what the current directory is, but you
+can easily run it in the ``xapian`` directory that was created earlier when you
+cloned the source code:
 
 .. code-block:: bash
 

--- a/getting-started/index.rst
+++ b/getting-started/index.rst
@@ -146,6 +146,27 @@ Building Xapian
 Bootstrapping the code
 ~~~~~~~~~~~~~~~~~~~~~~
 
+The easiest way of building Xapian from git master is to use our bootstrap
+script. It takes care of a number of things which are otherwise fiddly to get
+right, including checking you have the right version of various tools we use,
+and setting up the build system for you.
+
+.. note::
+
+   One things that bootstrap does is to set up a top-level ``configure`` script
+   which ensures that the in-tree version of ``xapian-core`` is built first and
+   then used for building everything else. You almost certainly want to build
+   Xapian this way.
+
+   Not using this means you have to check by hand that you're building other
+   subdirectories against the in-tree core library, as by default they will pick
+   any installed copy. An installed copy of Xapian is likely to be a different
+   version to the source tree you are building. Building the git master version
+   of Xapian against an earlier released library will probably fail. If you're
+   working on Xapian then you almost certainly want to build everything against
+   the in-tree version, so you should use ``bootstrap`` and the ``configure``
+   script it creates.
+
 The repository does not contain any automatically generated files
 (such as ``configure``, ``Makefile.in``, Snowball-generated stemmers, Lemon-generated
 parsers, SWIG-generated code, and so on) because experience shows it's best to keep

--- a/getting-started/index.rst
+++ b/getting-started/index.rst
@@ -196,7 +196,7 @@ with the ``--download-tools`` option to ``bootstrap``:
 ``--download-tools=ifneeded`` (the default)
        Download, patch and install autotools only if your installed version
        isn't recent enough, or if we have to apply patches that haven't yet
-       beenaccepted upstream.
+       been accepted upstream.
 
 ``--download-tools=never``
         Never download and install autotools; always use your installed
@@ -206,7 +206,7 @@ with the ``--download-tools`` option to ``bootstrap``:
         versions of the tools, and you may also fall foul of behaviour fixed
         in our patches.
 
-You can also asl the build system to delete the downloaded and installed
+You can also ask the build system to delete the downloaded and installed
 versions by passing ``--clean``.
 
 Our bootstrap script will check which directories you have checked out,

--- a/getting-started/index.rst
+++ b/getting-started/index.rst
@@ -184,16 +184,35 @@ cloned the source code:
 
    $ ./bootstrap
 
-To download tools, bootstrap will use ``wget``, ``curl`` or
+To download some tools, bootstrap will use ``wget``, ``curl`` or
 ``lwp-request`` if installed.  If not, it will give an error telling
-you the URL to download from by hand and where to copy the file to.
-If you wish to prevent bootstrap from downloading and building the autotools
-pass the ``--without-autotools`` option.  You can force it to delete the downloaded
-and installed versions by passing ``--clean``.
+you the URL to download from by hand and where to copy the file to. You
+can control whether Xapian tries to download, patch and install autotools
+with the ``--download-tools`` option to ``bootstrap``:
+
+``--download-tools=always``
+       Always download, patch and install autotools we rely on.
+
+``--download-tools=ifneeded`` (the default)
+       Download, patch and install autotools only if your installed version
+       isn't recent enough, or if we have to apply patches that haven't yet
+       beenaccepted upstream.
+
+``--download-tools=never``
+        Never download and install autotools; always use your installed
+        versions.
+
+        Note that in this case the build may fail if you have out of date
+        versions of the tools, and you may also fall foul of behaviour fixed
+        in our patches.
+
+You can also asl the build system to delete the downloaded and installed
+versions by passing ``--clean``.
 
 Our bootstrap script will check which directories you have checked out,
 so you can bootstrap a partial tree.  You can also ``touch .nobootstrap`` in
-a subdirectory to tell bootstrap to ignore it.
+a subdirectory to tell bootstrap to ignore it, or you can pass just the
+directories you want to build as arguments to ``bootstrap``.
 
 If you need to add any extra macro directories to the path searched by aclocal
 (which is part of automake), you can do this by specifying these in the

--- a/getting-started/index.rst
+++ b/getting-started/index.rst
@@ -127,6 +127,19 @@ tools installed:
 * `ccache <https://ccache.dev>`_ for faster rebuilds
 * `eatmydata <https://www.flamingspork.com/projects/libeatmydata/>`_ for faster testsuite runs
 
+If you want to be able to build distribution tarballs (with ``make dist``) then
+you'll also need some further tools:
+
+* doxygen (v1.8.8 is used for 1.3.x snapshots and releases; 1.7.6.1 fails to
+  process trunk after ``PL2Weight`` was added).
+* dot (part of Graphviz.  Doxygen's ``DOT_MULTI_TARGETS`` option apparently needs
+  ">1.8.10")
+* help2man
+* rst2html or rst2html.py (``pip install docutils``)
+* pngcrush (optional - used to reduce the size of PNG files in the HTML
+  apidocs)
+* sphinx-doc (``pip install sphinx`` should do)
+
 Building Xapian
 ---------------
 


### PR DESCRIPTION
This leaves HACKING with only three sections:

 * snapshots (which are covered on the website)
 * autotools versions (which are mostly notes to us about specific versions that do/don't work, and so probably belongs in the code still)
 * building using Vagrant (which isn't heavily used, and although it works isn't that efficient)